### PR TITLE
Fix: Reload persisted schedules on bot startup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -457,10 +457,78 @@ class MessageSchedulerBot:
             logger.error(f"Error in /list: {e}")
             await event.respond("An error occurred.")
 
+    async def reload_schedules_from_db(self):
+        logger.info("Attempting to reload schedules from database...")
+        # The query should find documents where 'sent' is not True (i.e., False or non-existent)
+        pending_schedules_cursor = self.collection.find({"sent": {"$ne": True}})
+
+        schedules_to_reload = []
+        # Iterate using an async for loop if the driver supports it,
+        # otherwise, convert cursor to list (may be memory intensive for large datasets)
+        # For pymongo, direct iteration is synchronous.
+        # If an async driver like motor is used, an async for loop would be appropriate here.
+        # Since we are using pymongo, a simple loop is fine, but the method is async
+        # to allow for potential async operations within the loop in the future (e.g., re-scheduling).
+        for schedule_doc in pending_schedules_cursor.to_list(length=None): # Use to_list for async compatibility if needed by driver
+            schedules_to_reload.append(schedule_doc)
+
+        if schedules_to_reload:
+            logger.info(f"Found {len(schedules_to_reload)} schedule(s) to reload.")
+            for schedule_doc in schedules_to_reload:
+                logger.debug(f"Attempting to re-schedule: {schedule_doc}")
+                message_id = str(schedule_doc['_id'])
+                chat_id = schedule_doc['chat_id'] # Assuming chat_id is stored in the document
+                schedule_name = schedule_doc.get('schedule_name', 'Unnamed Schedule')
+
+                interval_seconds = schedule_doc.get("interval_seconds")
+                schedule_time_str = schedule_doc.get("schedule_time")
+
+                if interval_seconds and isinstance(interval_seconds, (int, float)) and interval_seconds > 0:
+                    interval = int(interval_seconds)
+                    schedule.every(interval).seconds.do(
+                        self.send_scheduled_message, chat_id=chat_id, message_id=message_id
+                    ).tag(f"message_{message_id}")
+                    logger.info(f"Reloaded interval job for schedule '{schedule_name}' (ID: {message_id}) to run every {interval} seconds.")
+                elif schedule_time_str:
+                    try:
+                        parsed_schedule_time = datetime.strptime(schedule_time_str, "%Y-%m-%d %H:%M:%S")
+                        if parsed_schedule_time < datetime.now():
+                            logger.warning(f"Schedule '{schedule_name}' (ID: {message_id}) with time {schedule_time_str} is in the past. Skipping re-schedule and marking as sent.")
+                            self.collection.update_one({"_id": schedule_doc['_id']}, {"$set": {"sent": True}})
+                            continue
+                        else:
+                            job_time_str = parsed_schedule_time.strftime("%H:%M:%S")
+                            # For specific date scheduling, we might need to adjust how schedule.every().day.at() is used,
+                            # as it schedules for that time *every day*.
+                            # A more robust solution for future specific date-times would involve checking the date within send_scheduled_message
+                            # or using a library that supports one-off future jobs more directly if schedule doesn't handle it well for multi-day futures.
+                            # For now, adhering to the existing logic pattern from handle_conversation:
+                            schedule.every().day.at(job_time_str).do(
+                                self.send_scheduled_message, chat_id=chat_id, message_id=message_id
+                            ).tag(f"message_{message_id}")
+                            logger.info(f"Reloaded specific time job for schedule '{schedule_name}' (ID: {message_id}) for {schedule_time_str}.")
+                            # Note: This will make it run daily at that time until 'sent' is true.
+                            # If it's truly one-time, send_scheduled_message should ensure it's marked 'sent' and cancels the job.
+                    except ValueError:
+                        logger.error(f"Invalid date format for schedule '{schedule_name}' (ID: {message_id}): {schedule_time_str}. Cannot reload.")
+                    except Exception as e:
+                        logger.error(f"Error processing schedule_time for '{schedule_name}' (ID: {message_id}): {e}")
+                else:
+                    logger.warning(f"Schedule '{schedule_name}' (ID: {message_id}) has no valid interval_seconds or schedule_time. Cannot reload.")
+        else:
+            logger.info("No pending schedules found in the database to reload.")
+        # Return the list of schedules for now, as it might be useful for testing or direct inspection
+        return schedules_to_reload
+
     async def run(self):
         try:
             await self.client.start(bot_token=self.bot_token)
             logger.info("Bot started successfully")
+
+            # Reload schedules from the database
+            await self.reload_schedules_from_db()
+
+            logger.info("Starting schedule polling loop...")
             while True:
                 schedule.run_pending()
                 await asyncio.sleep(CONFIG['SCHEDULE_CHECK_INTERVAL_SECONDS'])


### PR DESCRIPTION
Previously, all scheduled messages managed by the 'schedule' library were lost upon bot restart because they were stored in-memory. While message details were persisted in MongoDB, the schedule jobs themselves were not being recreated.

This change addresses the issue by:
1. Adding a `reload_schedules_from_db` method to `MessageSchedulerBot`. This method fetches all non-sent messages from the MongoDB collection at startup.
2. Re-creating the schedule jobs within this method:
   - Interval-based schedules are re-added using `schedule.every().seconds.do()`.
   - Specific-time schedules are re-added using `schedule.every().day.at()`.
   - Schedules with a specific time in the past are logged, skipped for re-scheduling, and marked as 'sent' in the database.
3. Calling `reload_schedules_from_db` in the `run` method after the Telegram client successfully starts and before the main scheduling loop begins.
4. Ensuring appropriate logging is present for the reloading process, including the number of schedules reloaded and any issues encountered.

This ensures that previously scheduled messages resume their schedules after a bot restart, preventing data loss and improving reliability.